### PR TITLE
Manny: `requestPremission` method fix (TF-733)

### DIFF
--- a/common/Reminders.swift
+++ b/common/Reminders.swift
@@ -24,24 +24,19 @@ class Reminders {
     func requestPermission() -> Bool {
         var granted = false
         let semaphore = DispatchSemaphore(value: 0)
-        if #available(iOS 17.0.0, *) {
 
-            if #available(macOS 14.0, *) {
-                eventStore.requestFullAccessToReminders(completion: { (success, error) in
-                    granted = success
-                    semaphore.signal()
-                })
-            } else {
-                // Fallback on earlier versions
-            }
-
-        }else{
-            eventStore.requestAccess(to: EKEntityType.reminder) { (success, error) in
+        if #available(iOS 17.0, macOS 14.0, *) {
+            eventStore.requestFullAccessToReminders { (success, error) in
                 granted = success
                 semaphore.signal()
             }
-
+        } else {
+            eventStore.requestAccess(to: .reminder) { (success, error) in
+                granted = success
+                semaphore.signal()
+            }
         }
+
         semaphore.wait()
         hasAccess = granted
         return granted


### PR DESCRIPTION
(PR created on Manny's behalf. Notes below ported from his comments in Slack.)

### In this PR
- Successfully fixed the issue related to Reminders (TF-733). It now works as expected on both iOS and macOS.

### Follow up items
While verifying the fix and doing some testing, I identified two additional issues that need attention:
1. macOS Device Calendar issue
    - During debugging, I encountered a "No calendar found" issue on macOS. The recent fix I implemented was focused solely on iOS, so we need to address this issue on macOS as well.
3. ReminderSync and CalendarSync Sequence
    - There is a problem when activating both the ReminderSync and CalendarSync toggles. When the second toggle is activated, a settings redirection dialog appears. For instance, if ReminderSync is activated first, it works fine, but activating CalendarSync subsequently triggers the dialog.
     ![image](https://github.com/TimeFinderApp/reminders/assets/1598289/90973c29-1e97-4a41-a3e7-9b117f2f8832)


